### PR TITLE
Correctly set the license type in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "icon": "webpack -c ./webpack.config.icon.ts && node temp/igen.js && rm -rv temp"
   },
   "author": "Nicolas Ventura",
-  "license": "Apache-2.0",
+  "license": "BSD-3-Clause-LBNL",
   "devDependencies": {
     "@babel/core": "^7.21.4",
     "@grafana/e2e": "10.0.3",


### PR DESCRIPTION
The license text appears to correspond with the BSD-3-Clause-LBNL SPDX identifier.